### PR TITLE
화면 겹치는거 때문에 약간 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -41,5 +41,15 @@
       <option name="name" value="maven" />
       <option name="url" value="http://devrepo.kakao.com:8088/nexus/content/groups/public/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="file:/$PROJECT_DIR$/repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="file:/$PROJECT_DIR$/app/repo1.maven.org/maven2" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="16" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,10 @@ android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
 
+    lintOptions {
+        disable "Instantiatable"
+    }
+
     defaultConfig {
         applicationId "org.androidtown.disfactch"
         minSdkVersion 19
@@ -35,7 +39,9 @@ dependencies {
     implementation "com.kakao.sdk:v2-user:2.5.1" // 카카오 로그인
     implementation "com.kakao.sdk:v2-talk:2.5.1" // 친구, 메시지(카카오톡)
     implementation "com.kakao.sdk:v2-link:2.5.1" // 메시지(카카오링크)
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="org.androidtown.disfactch">
 
     <!--queries에 카카오톡 패키지 추가-->
@@ -17,7 +18,6 @@
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Disfactch">
-        <activity android:name=".MainActivity" />
 
         <activity
             android:name=".SplashActivity"
@@ -29,6 +29,18 @@
 
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".MainActivity"
+            android:windowSoftInputMode="stateAlwaysHidden"
+            android:configChanges="orientation"
+            android:theme="@style/Theme.Disfactch.NoActionBar">
+        </activity>
+
+        <activity
+            android:name=".FactCheckingFragment"
+            android:configChanges="uiMode"
+            tools:ignore="Instantiatable" />
 
     </application>
 

--- a/app/src/main/java/org/androidtown/disfactch/FactCheckingFragment.java
+++ b/app/src/main/java/org/androidtown/disfactch/FactCheckingFragment.java
@@ -29,12 +29,12 @@ public class FactCheckingFragment extends Fragment implements CircleProgressBar.
     BrowseFragment web;
 
 
-
     EditText link;
     CircleProgressBar cb_prov;// 자극성 기사 progress bar
     CircleProgressBar cb_pub; // 홍보성 기사
     CircleProgressBar cb_sa; // 동일 기사
     CircleProgressBar cb_fi; // 최종 신뢰도
+
 
 /*
     @Override

--- a/app/src/main/java/org/androidtown/disfactch/SettingFragment.java
+++ b/app/src/main/java/org/androidtown/disfactch/SettingFragment.java
@@ -88,14 +88,17 @@ public class SettingFragment extends Fragment {
             }
         });
 
+
         sw_dark = (Switch)v.findViewById(R.id.sw);
 
         sw_dark.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
 
+        //TODO: 여기서 onConfigurationChanged 메서드를 써야할 것 같은데
             @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked){
 
                 if(isChecked){
                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+
                 }else{
                     AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
                 }

--- a/app/src/main/res/layout/fragment_fact_checking.xml
+++ b/app/src/main/res/layout/fragment_fact_checking.xml
@@ -71,6 +71,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="300dp">
 
+
         <com.dinuscxj.progressbar.CircleProgressBar
             android:id="@+id/cb_provocative"
             android:layout_width="100dp"

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -17,8 +17,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Setting"
-            android:textStyle="bold"
-            android:textSize="20sp"/>
+            android:textSize="20sp"
+            android:textStyle="bold" />
 
 
         <!-- TODO : 버튼 이름 변경 필요 > settingFragment.java도 변경 -->

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Disfactch" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.Disfactch" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Disfactch" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.Disfactch" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
+
+
         //classpath "com.android.tools.build:gradle:4.2.0"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,8 +18,12 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'http://devrepo.kakao.com:8088/nexus/content/groups/public/' }
-        jcenter() // Warning: this repository is going to shut down soon
+        maven {
+            //url 'repo1.maven.org/maven2';
+            url 'http://devrepo.kakao.com:8088/nexus/content/groups/public/'
+            allowInsecureProtocol = true
+        }
+        jcenter()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 13 01:56:06 KST 2021
+#Wed Oct 13 18:06:09 KST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Appcompat 버전이 1.1.0 이상인 경우
앱 테마가 변경되면 uiMode 구성 변경이 트리거 돼서 Activity가 자동으로 생긴다
그래서 AndroidManifest.xml 에 uiMode 구성변경 처리 선언하면 (여기까지 수행함)
onConfigurationChanged 메서드가 호출이 된다 -> Activity 겹치지 않고 다크모드 적용가능

그래서 onCheckedChanged 메소드를 onConfigurationChanged 메소드로 변경해야 트리거가 안 생기지 않을까 근데 어떻게 손을 대야할지 모르겠습니다 . .. ㅜㅜ!

